### PR TITLE
Update to SDK 6.3 and NixOS 23.05

### DIFF
--- a/overlay/default.nix
+++ b/overlay/default.nix
@@ -6,9 +6,9 @@ self: super:
     sdk = self.callPackage ./sdk {
       libpng = super.libpng12;
       libjpeg = self.libjpeg8;
-      sdkver = "3.0.12";
-      revision = "2019-06-12-77ed6f47e";
-      sha256 = "0pc1vgfm3gdw0bc06602k78q658r4x9144nvaidqnagn7iaq9b86";
+      sdkver = "6.3.0";
+      revision = "2023-08-29-fc81ed416";
+      sha256 = "sha256-A4rU0B9MYz5XxRLWEhqjQPyngFgH1z81O1FlLXppkkk=";
     };
 
     beta_sdk = self.callPackage ./sdk {

--- a/overlay/libjpeg/default.nix
+++ b/overlay/libjpeg/default.nix
@@ -1,23 +1,24 @@
-{ stdenv, fetchurl, static ? false }:
+{ stdenv, fetchurl, lib, static ? false }:
 
-with stdenv.lib;
-
-stdenv.mkDerivation {
-  name = "libjpeg-8d";
+let
+  version = "8d";
+in stdenv.mkDerivation {
+  pname = "libjpeg";
+  version = version;
 
   src = fetchurl {
-    url = http://www.ijg.org/files/jpegsrc.v8d.tar.gz;
-    sha256 = "1cz0dy05mgxqdgjf52p54yxpyy95rgl30cnazdrfmw7hfca9n0h0";
+    url = "http://www.ijg.org/files/jpegsrc.v${version}.tar.gz";
+    sha256 = "sha256-/cTUwRM4rQKKfSP7U/W7k1RnE5Kmf7G1LgwypxIYkfg=";
   };
 
-  configureFlags = optional static "--enable-static --disable-shared";
+  configureFlags = lib.optional static "--enable-static --disable-shared";
 
-  outputs = [ "bin" "dev" "out" "man" ];
+  outputs = [ "out" "dev" "bin" "man" ];
 
-  meta = {
-    homepage = http://www.ijg.org/;
+  meta = with lib; {
+    homepage = "http://www.ijg.org/";
     description = "A library that implements the JPEG image file format";
-    license = stdenv.lib.licenses.free;
-    platforms = stdenv.lib.platforms.unix;
+    license = licenses.free;
+    platforms = platforms.unix;
   };
 }

--- a/overlay/sdk/default.nix
+++ b/overlay/sdk/default.nix
@@ -1,6 +1,7 @@
 { stdenv
+, lib
 , fetchurl
-, jdk8
+, openjdk
 , unzip
 , runtimeShell
 , autoPatchelfHook
@@ -8,8 +9,8 @@
 # autoPatchelfHook libraries
 , libusb1
 , zlib
-, webkitgtk24x-gtk2
-, xlibs
+, webkitgtk
+, xorg
 , libjpeg
 , libpng
 
@@ -21,9 +22,8 @@
 }:
 
 let
-  inherit (stdenv.lib) makeBinPath;
-  binPath = makeBinPath [
-    jdk8
+  binPath = lib.makeBinPath [
+    openjdk
   ];
 in
 stdenv.mkDerivation rec {
@@ -53,8 +53,8 @@ stdenv.mkDerivation rec {
   buildInputs = [
     libusb1
     zlib
-    webkitgtk24x-gtk2
-    xlibs.libXxf86vm
+    webkitgtk
+    xorg.libXxf86vm
     libjpeg
     libpng
   ];
@@ -78,11 +78,14 @@ stdenv.mkDerivation rec {
     done
   '';
 
-  meta = {
+  meta = with lib; {
+    description = "Connect IQ SDK";
+    homepage = "https://developer.garmin.com/connect-iq-sdk/";
     license = {
       fullName = "Connect IQ License Agreement";
       url = "https://developer.garmin.com/connect-iq/license-agreement/";
       free = false;
     };
+    platforms = platforms.linux;
   };
 }


### PR DESCRIPTION
This is a work in progress regarding the support of the latest version of the Connect IQ SDK.

I updated the version of the SDK and fixed changes in Nix variables.

I am now facing an issue of `Read-only file system`, and don't know how to solve it yet.

```shell
$ nix-shell

$ monkeyc -y developer_key.der  -f /nix/store/rsgpkgyhsrz96wyd10ha4dhbm5rgygw1-connectiq-sdk-6.3.0-2023-08-29-fc81ed416/share/connectiq-sdk/samples/Attention/monkey.jungle  -o Attention.prg
ERROR: Unable to generate default.jungle: Read-only file system
usage: monkeyc [-a <arg>] [-b <arg>] [--build-stats <arg>] [-c <arg>] [-d <arg>]
(...)
```